### PR TITLE
Add timeout to WsfRemoteClient

### DIFF
--- a/Client/src/main/java/org/gusdb/wsf/client/WsfRemoteClient.java
+++ b/Client/src/main/java/org/gusdb/wsf/client/WsfRemoteClient.java
@@ -94,9 +94,6 @@ public class WsfRemoteClient implements WsfClient {
       signal = readStream(inStream, stats);
     }
     catch (ClassNotFoundException | IOException ex) {
-      try {
-        LOG.debug(new String(inStream.readAllBytes(), StandardCharsets.UTF_8));
-      } catch (IOException e) {}
       throw new ClientModelException(ex);
     }
     finally {

--- a/Client/src/main/java/org/gusdb/wsf/client/WsfRemoteClient.java
+++ b/Client/src/main/java/org/gusdb/wsf/client/WsfRemoteClient.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -94,6 +95,9 @@ public class WsfRemoteClient implements WsfClient {
       signal = readStream(inStream, stats);
     }
     catch (ClassNotFoundException | IOException ex) {
+      try {
+        LOG.debug(new String(inStream.readAllBytes(), StandardCharsets.UTF_8));
+      } catch (IOException e) {}
       throw new ClientModelException(ex);
     }
     finally {

--- a/Client/src/main/java/org/gusdb/wsf/client/WsfRemoteClient.java
+++ b/Client/src/main/java/org/gusdb/wsf/client/WsfRemoteClient.java
@@ -58,11 +58,10 @@ public class WsfRemoteClient implements WsfClient {
     Form form = new Form();
     form.param(WsfRequest.PARAM_REQUEST, request.toString());
 
-    LOG.debug("Context: " + request.getContext());
     // invoke service
-    final Optional<Duration> timeout = request.getRemoteExecuteTimeout();
     Response response;
     try {
+      final Optional<Duration> timeout = request.getRemoteExecuteTimeout();
       final Future<Response> responseFuture = client.target(serviceURI)
           .property(ClientProperties.FOLLOW_REDIRECTS, Boolean.TRUE)
           .request(MediaType.APPLICATION_OCTET_STREAM_TYPE)

--- a/Client/src/main/java/org/gusdb/wsf/client/WsfRemoteClient.java
+++ b/Client/src/main/java/org/gusdb/wsf/client/WsfRemoteClient.java
@@ -4,8 +4,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.net.URI;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -51,10 +57,29 @@ public class WsfRemoteClient implements WsfClient {
     Form form = new Form();
     form.param(WsfRequest.PARAM_REQUEST, request.toString());
 
+    LOG.debug("Context: " + request.getContext());
     // invoke service
-    Response response = client.target(serviceURI).property(ClientProperties.FOLLOW_REDIRECTS, Boolean.TRUE).request(
-        MediaType.APPLICATION_OCTET_STREAM_TYPE).post(
-        Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
+    final Optional<Duration> timeout = request.getRemoteExecuteTimeout();
+    Response response;
+    try {
+      final Future<Response> responseFuture = client.target(serviceURI)
+          .property(ClientProperties.FOLLOW_REDIRECTS, Boolean.TRUE)
+          .request(MediaType.APPLICATION_OCTET_STREAM_TYPE)
+          .async()
+          .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
+      if (timeout.isPresent()) {
+        response = responseFuture.get(timeout.get().toMillis(), TimeUnit.MILLISECONDS);
+      } else {
+        response = responseFuture.get();
+      }
+    } catch (InterruptedException ex) {
+      LOG.warn(String.format("Interrupted while invoking service at %s.", serviceURI.toString()), ex);
+      Thread.currentThread().interrupt();
+      throw new ClientModelException(ex);
+    } catch (ExecutionException | TimeoutException ex) {
+      LOG.warn(String.format("Exception while invoking service at %s.", serviceURI.toString()), ex);
+      throw new ClientModelException(ex);
+    }
     int status = response.getStatus();
     if (status >= 400)
       throw new ClientModelException("Request failed with status code: " + status);

--- a/Client/src/main/java/org/gusdb/wsf/client/WsfRemoteClient.java
+++ b/Client/src/main/java/org/gusdb/wsf/client/WsfRemoteClient.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;

--- a/Common/src/main/java/org/gusdb/wsf/common/WsfRequest.java
+++ b/Common/src/main/java/org/gusdb/wsf/common/WsfRequest.java
@@ -5,7 +5,7 @@ import java.util.Map;
 public interface WsfRequest {
 
   String PARAM_REQUEST = "request";
-  String REMOTE_EXECUTE_TIMEOUT_ISO_8601_CONTEXT_KEY = "timeout_in_millis";
+  String REMOTE_EXECUTE_TIMEOUT_ISO_8601_CONTEXT_KEY = "timeout_iso_8601";
 
   /**
    * @return the projectId

--- a/Common/src/main/java/org/gusdb/wsf/common/WsfRequest.java
+++ b/Common/src/main/java/org/gusdb/wsf/common/WsfRequest.java
@@ -5,6 +5,7 @@ import java.util.Map;
 public interface WsfRequest {
 
   String PARAM_REQUEST = "request";
+  String REMOTE_EXECUTE_TIMEOUT_ISO_8601_CONTEXT_KEY = "timeout_in_millis";
 
   /**
    * @return the projectId

--- a/Plugin/src/main/java/org/gusdb/wsf/plugin/PluginRequest.java
+++ b/Plugin/src/main/java/org/gusdb/wsf/plugin/PluginRequest.java
@@ -1,11 +1,7 @@
 package org.gusdb.wsf.plugin;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.time.Duration;
+import java.util.*;
 
 import org.gusdb.fgputil.json.JsonUtil;
 import org.gusdb.wsf.common.WsfRequest;
@@ -211,6 +207,20 @@ public class PluginRequest implements WsfRequest {
    */
   public void setContext(Map<String, String> context) {
     this._context = new HashMap<>(context);
+  }
+
+  public void appendContext(String key, String value) {
+    this._context = new HashMap<>(_context);
+    this._context.put(key, value);
+  }
+
+  public void setContextTimeout(Duration value) {
+    this.appendContext(REMOTE_EXECUTE_TIMEOUT_ISO_8601_CONTEXT_KEY, value.toString());
+  }
+
+  public Optional<Duration> getRemoteExecuteTimeout() {
+    return Optional.ofNullable(this._context.get(REMOTE_EXECUTE_TIMEOUT_ISO_8601_CONTEXT_KEY))
+        .map(Duration::parse);
   }
 
 }

--- a/Plugin/src/main/java/org/gusdb/wsf/plugin/PluginRequest.java
+++ b/Plugin/src/main/java/org/gusdb/wsf/plugin/PluginRequest.java
@@ -220,7 +220,8 @@ public class PluginRequest implements WsfRequest {
 
   public Optional<Duration> getRemoteExecuteTimeout() {
     return Optional.ofNullable(this._context.get(REMOTE_EXECUTE_TIMEOUT_ISO_8601_CONTEXT_KEY))
-        .map(Duration::parse);
+        .map(Duration::parse)
+        .filter(duration -> !duration.isZero());
   }
 
 }


### PR DESCRIPTION
(Partly) Resolves [WDK#18](https://github.com/VEuPathDB/WDK/issues/18).

NOTE: I haven't removed the old timeout code, which still serves some small purpose but may not be necessary.

The old code only times out if we run out of time after the response comes back while adding the rows of the response to the WsfResponseListener.